### PR TITLE
fix: LCIMethodAndAllocation missing "other" field

### DIFF
--- a/.github/workflows/publish_python.yaml
+++ b/.github/workflows/publish_python.yaml
@@ -79,3 +79,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false

--- a/modules/convert/src/ilcd/ilcd.rs
+++ b/modules/convert/src/ilcd/ilcd.rs
@@ -182,7 +182,7 @@ pub struct ReferenceToLCIAMethodDataSet {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LCIMethodAndAllocation {
-    pub other: Anies,
+    pub other: Option<Anies>,
 }
 
 #[derive(Deserialize)]

--- a/modules/convert/tests/ilcd/datafixtures/b56530ee-77bf-49bd-7997-08d972c43176.json
+++ b/modules/convert/tests/ilcd/datafixtures/b56530ee-77bf-49bd-7997-08d972c43176.json
@@ -1,0 +1,3883 @@
+{
+  "processInformation": {
+    "dataSetInformation": {
+      "UUID": "b56530ee-77bf-49bd-7997-08d972c43176",
+      "name": {
+        "baseName": [
+          {
+            "value": "EPD-IES-0003435:001 (S-P-03435) Engineered wood flooring",
+            "lang": "en"
+          }
+        ]
+      },
+      "synonyms": [
+        {
+          "value": "EPD-IES-0003435:001 (S-P-03435)",
+          "lang": "en"
+        }
+      ]
+    },
+    "quantitativeReference": {
+      "referenceToReferenceFlow": [
+        0
+      ],
+      "type": "Reference flow(s)"
+    },
+    "time": {
+      "referenceYear": 2023,
+      "dataSetValidUntil": 2028,
+      "timeRepresentativenessDescription": [
+        {
+          "lang": "en"
+        }
+      ]
+    },
+    "geography": {
+      "locationOfOperationSupplyOrProduction": {
+        "location": "ID"
+      }
+    }
+  },
+  "modellingAndValidation": {
+    "LCIMethodAndAllocation": {
+      "typeOfDataSet": "EPD",
+      "referenceToLCAMethodDetails": [
+        {
+          "shortDescription": [
+            {
+              "value": "Construction products (EN 15804A2)",
+              "lang": "en"
+            }
+          ],
+          "type": "source data set",
+          "refObjectId": "45538f2e-17c0-49fd-a543-b1a02ac27658",
+          "version": "00.00.001"
+        }
+      ]
+    },
+    "dataSourcesTreatmentAndRepresentativeness": {
+      "referenceToDataSource": [
+        {
+          "shortDescription": [
+            {
+              "value": "ecoinvent database (general)",
+              "lang": "en"
+            }
+          ],
+          "type": "source data set",
+          "refObjectId": "b497a91f-e14b-4b69-8f28-f50eb1576766"
+        },
+        {
+          "shortDescription": [
+            {
+              "value": "ecoinvent 3.8 database",
+              "lang": "en"
+            }
+          ],
+          "type": "source data set",
+          "refObjectId": "0f4c65c0-6210-450f-b886-82bf8dd5ace9"
+        }
+      ],
+      "other": {
+        "anies": [
+          {
+            "name": "referenceToOriginalEPD",
+            "value": {
+              "shortDescription": {
+                "value": "EPD-IES-0003435:001 (S-P-03435) Engineered wood flooring",
+                "defaultValue": "EPD-IES-0003435:001 (S-P-03435) Engineered wood flooring",
+                "lstrings": [
+                  {
+                    "lang": "en",
+                    "value": "EPD-IES-0003435:001 (S-P-03435) Engineered wood flooring"
+                  }
+                ]
+              },
+              "version": {
+                "version": 1,
+                "majorVersion": 0,
+                "minorVersion": 0,
+                "subMinorVersion": 1,
+                "zero": false,
+                "versionString": "00.00.001"
+              },
+              "type": "source data set",
+              "uuid": {
+                "uuid": "47c78255-869a-40ec-b003-08d972c43176"
+              },
+              "refObjectId": "47c78255-869a-40ec-b003-08d972c43176",
+              "versionAsString": "00.00.001",
+              "resourceURLs": [
+                "https://data.environdec.com/resource/sources/47c78255-869a-40ec-b003-08d972c43176/https://www.environdec.com/Detail/epd3435?version=00.00.001"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "validation": {
+      "review": [
+        {
+          "type": "Independent internal review"
+        }
+      ]
+    },
+    "complianceDeclarations": {
+      "compliance": [
+        {
+          "referenceToComplianceSystem": {
+            "shortDescription": [
+              {
+                "value": "EN 15804+A2",
+                "lang": "en"
+              }
+            ],
+            "type": "source data set",
+            "refObjectId": "c0016b33-8cf7-415c-ac6e-deba0d21440d",
+            "version": "00.02.000"
+          }
+        },
+        {
+          "referenceToComplianceSystem": {
+            "shortDescription": [
+              {
+                "value": "ISO 14025",
+                "lang": "en"
+              }
+            ],
+            "type": "source data set",
+            "refObjectId": "4f2eb655-6e44-4874-a95a-e28f5442cd4d",
+            "version": "00.00.004"
+          }
+        }
+      ]
+    },
+    "other": {
+      "anies": [
+        {
+          "name": "referenceToOriginalEPD",
+          "value": {
+            "shortDescription": [
+              {
+                "value": "EPD-IES-0003435:001 (S-P-03435) Engineered wood flooring",
+                "lang": "en"
+              }
+            ],
+            "type": "source data set",
+            "refObjectId": "47c78255-869a-40ec-b003-08d972c43176",
+            "version": "00.00.001"
+          }
+        }
+      ]
+    }
+  },
+  "administrativeInformation": {
+    "dataEntryBy": {
+      "timeStamp": 1711350991043,
+      "referenceToDataSetFormat": [
+        {
+          "shortDescription": [
+            {
+              "value": "EPD Data Format Extension",
+              "lang": "en"
+            }
+          ],
+          "type": "source data set",
+          "refObjectId": "cba73800-7874-11e3-981f-0800200c9a66",
+          "version": "00.01.000"
+        },
+        {
+          "shortDescription": [
+            {
+              "value": "ILCD format",
+              "lang": "en"
+            }
+          ],
+          "type": "source data set",
+          "refObjectId": "a97a0155-0234-4b87-b4ce-a45da52f2a40",
+          "version": "01.00.000",
+          "uri": "http://lca.jrc.ec.europa.eu/lcainfohub/sample_data/ilcd/sources/ILCD_Format_a97a0155-0234-4b87-b4ce-a45da52f2a40_01.00.000.xml"
+        }
+      ],
+      "referenceToPersonOrEntityEnteringTheData": {
+        "shortDescription": [
+          {
+            "value": "The International EPD System",
+            "lang": "en"
+          }
+        ],
+        "type": "contact data set",
+        "refObjectId": "5e09bd06-11a1-4292-a56b-47898ad6a691",
+        "version": "00.00.001"
+      }
+    },
+    "publicationAndOwnership": {
+      "dataSetVersion": "07.01.002",
+      "referenceToOwnershipOfDataSet": {
+        "shortDescription": [
+          {
+            "value": "PT Kayu Lapis Indonesia",
+            "lang": "en"
+          }
+        ],
+        "type": "contact data set",
+        "refObjectId": "63db270c-88b8-47e0-a507-08dbbebf2c2b",
+        "version": "00.00.001"
+      },
+      "accessRestrictions": [
+        {
+          "value": "Your use of this material is subject to the General Terms of Use published on by EPD International AB:s homepage at https://www.environdec.com/contact/General-terms-of-use/. If you have not accepted EPD International AB:s the General Terms of Use, you are not authorized to exploit this work in any manner.",
+          "lang": "en"
+        }
+      ]
+    }
+  },
+  "exchanges": {
+    "exchange": [
+      {
+        "dataSetInternalID": 0,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Engineered wood flooring",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "50034c74-2047-49e7-88f2-43a4a25c1270",
+          "version": "00.01.000"
+        },
+        "meanAmount": 1.0,
+        "referenceFlow": true,
+        "resultingflowAmount": 1.0,
+        "flowProperties": [
+          {
+            "name": [
+              {
+                "lang": "en",
+                "value": "Area"
+              }
+            ],
+            "uuid": "93a60a56-a3c8-19da-a746-0800200c9a66",
+            "referenceFlowProperty": true,
+            "meanValue": 1.0,
+            "referenceUnit": "m2",
+            "unitGroupUUID": "93a60a57-a3c8-18da-a746-0800200c9a66"
+          }
+        ],
+        "typeOfFlow": "Product flow"
+      },
+      {
+        "dataSetInternalID": 1,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of renewable primary energy as energy carrier (PERE)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "20f32be5-0398-4288-9b6d-accddd195317"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "637",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.0831",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.19",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0347",
+              "module": "C1"
+            },
+            {
+              "value": "0.00535",
+              "module": "C2"
+            },
+            {
+              "value": "0.159",
+              "module": "C3"
+            },
+            {
+              "value": "0.00877",
+              "module": "C4"
+            },
+            {
+              "value": "-29.1",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 2,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of renewable primary energy resources used as raw materials (PERM)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "fb3ec0de-548d-4508-aea5-00b73bf6f702"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "306",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 3,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Total use of renewable primary energy (PERT)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "53f97275-fa8a-4cdd-9024-65936002acd0"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "943",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.0831",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.19",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0347",
+              "module": "C1"
+            },
+            {
+              "value": "0.00535",
+              "module": "C2"
+            },
+            {
+              "value": "0.159",
+              "module": "C3"
+            },
+            {
+              "value": "0.00877",
+              "module": "C4"
+            },
+            {
+              "value": "-29.1",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 4,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of non renewable primary energy as energy carrier (PENRE)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "ac857178-2b45-46ec-892a-a9a4332f0372"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "414",
+              "module": "A1-A3"
+            },
+            {
+              "value": "69.2",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "4.78",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.297",
+              "module": "C1"
+            },
+            {
+              "value": "4.87",
+              "module": "C2"
+            },
+            {
+              "value": "1.36",
+              "module": "C3"
+            },
+            {
+              "value": "4.69",
+              "module": "C4"
+            },
+            {
+              "value": "24.3",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 5,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of non renewable primary energy resources used as raw materials (PENRM)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "1421caa0-679d-4bf4-b282-0eb850ccae27"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.241",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 6,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Total use of non renewable primary energy resource (PENRT)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "06159210-646b-4c8d-8583-da9b3b95a6c1"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "414",
+              "module": "A1-A3"
+            },
+            {
+              "value": "69.2",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "4.78",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.297",
+              "module": "C1"
+            },
+            {
+              "value": "4.87",
+              "module": "C2"
+            },
+            {
+              "value": "1.36",
+              "module": "C3"
+            },
+            {
+              "value": "4.69",
+              "module": "C4"
+            },
+            {
+              "value": "24.3",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 7,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of secondary material (SM)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "c6a1f35f-2d09-4f54-8dfb-97e502e1ce92"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 8,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of renewable secondary fuels (RSF)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "64333088-a55f-4aa2-9a31-c10b07816787"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "225",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "30.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Gr\u00f6\u00dfen / Umweltliche Gr\u00f6\u00dfen / EPD EN 15804 / LCI Indikatoren",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 9,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Use of non renewable secondary fuels (NRSF)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "89def144-d39a-4287-b86f-efde453ddcb2"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "30.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Gr\u00f6\u00dfen / Umweltliche Gr\u00f6\u00dfen / EPD EN 15804 / LCI Indikatoren",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 10,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Net use of fresh water (FW)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "3cf952c8-f3a4-461d-8c96-96456ca62246"
+        },
+        "exchange direction": "INPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "1.58",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.0151",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0182",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.00186",
+              "module": "C1"
+            },
+            {
+              "value": "0.00124",
+              "module": "C2"
+            },
+            {
+              "value": "0.00851",
+              "module": "C3"
+            },
+            {
+              "value": "0.00151",
+              "module": "C4"
+            },
+            {
+              "value": "0.103",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "m3"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "cd950537-0a98-4044-9ba7-9f9a68d0a504",
+                "uri": "../unitgroups/cd950537-0a98-4044-9ba7-9f9a68d0a504"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 11,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Hazardous waste disposed (HWD)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "430f9e0f-59b2-46a0-8e0d-55e0e84948fc"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.00416",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.00656",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0.000286",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 12,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Non harzardous waste disposed (NHWD)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "b29ef66b-e286-4afa-949f-62f1a7b4d7fa"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "-0.0446",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0.837",
+              "module": "C4"
+            },
+            {
+              "value": "0.0191",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 13,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Radioactive waste disposed (RWD)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "3449546e-52ad-4b39-b809-9fb77cea8ff6"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 14,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Components for re-use (CRU)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "a2b32f97-3fc7-4af2-b209-525bc6426f33"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "30.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Gr\u00f6\u00dfen / Umweltliche Gr\u00f6\u00dfen / EPD EN 15804 / LCI Indikatoren",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 15,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Materials for recycling (MFR)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "d7fe48a5-4103-49c8-9aae-b0b5dfdbd6ae"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0.209",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "30.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Gr\u00f6\u00dfen / Umweltliche Gr\u00f6\u00dfen / EPD EN 15804 / LCI Indikatoren",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 16,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Materials for energy recovery (MER)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "59a9181c-3aaf-46ee-8b13-2b3723b6e447"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "4.09",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0.227",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "ad38d542-3fe9-439d-9b95-2f5f7752acaf",
+                "uri": "../unitgroups/ad38d542-3fe9-439d-9b95-2f5f7752acaf"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "30.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Gr\u00f6\u00dfen / Umweltliche Gr\u00f6\u00dfen / EPD EN 15804 / LCI Indikatoren",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 17,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Exported electrical energy (EEE)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "4da0c987-2b76-40d6-9e9e-82a017aaaf29"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      },
+      {
+        "dataSetInternalID": 18,
+        "referenceToFlowDataSet": {
+          "shortDescription": [
+            {
+              "value": "Exported thermal energy (EET)",
+              "lang": "en"
+            }
+          ],
+          "type": "flow data set",
+          "refObjectId": "98daf38a-7a79-46d3-9a37-2b7bd0955810"
+        },
+        "exchange direction": "OUTPUT",
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0",
+              "module": "C1"
+            },
+            {
+              "value": "0",
+              "module": "C2"
+            },
+            {
+              "value": "0",
+              "module": "C3"
+            },
+            {
+              "value": "0",
+              "module": "C4"
+            },
+            {
+              "value": "0",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        },
+        "resolvedFlowVersion": "35.00.000",
+        "flowProperties": [],
+        "typeOfFlow": "Other flow",
+        "classification": {
+          "classHierarchy": "Quantities / Environmental quantities / EPD EN 15804 / LCI indicators",
+          "name": "GaBiCategories"
+        }
+      }
+    ]
+  },
+  "LCIAResults": {
+    "LCIAResult": [
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Global Warming Potential - fossil fuels (GWP-fossil)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "5f635281-343e-44fb-83df-1971b155e6b6",
+          "uri": "../lciamethods/5f635281-343e-44fb-83df-1971b155e6b6"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "30.438391",
+              "module": "A1-A3"
+            },
+            {
+              "value": "4.8520439",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.24172773",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.021783413",
+              "module": "C1"
+            },
+            {
+              "value": "0.32399921",
+              "module": "C2"
+            },
+            {
+              "value": "0.099832625",
+              "module": "C3"
+            },
+            {
+              "value": "0.3061803",
+              "module": "C4"
+            },
+            {
+              "value": "1.3937763",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg CO2 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "1ebf3012-d0db-4de2-aefd-ef30cedb0be1",
+                "uri": "../unitgroups/1ebf3012-d0db-4de2-aefd-ef30cedb0be1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Global Warming Potential - biogenic (GWP-biogenic)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "2356e1ab-0185-4db5-86e5-16de51c7485c",
+          "uri": "../lciamethods/2356e1ab-0185-4db5-86e5-16de51c7485c"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "-41.056986",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.003110934",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0062358183",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.00025269177",
+              "module": "C1"
+            },
+            {
+              "value": "0.00021830054",
+              "module": "C2"
+            },
+            {
+              "value": "42.0210586747",
+              "module": "C3"
+            },
+            {
+              "value": "0.084421393",
+              "module": "C4"
+            },
+            {
+              "value": "0.0048800288",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg CO2 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "1ebf3012-d0db-4de2-aefd-ef30cedb0be1",
+                "uri": "../unitgroups/1ebf3012-d0db-4de2-aefd-ef30cedb0be1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Global Warming Potential - land use and land use change (GWP-luluc)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "4331bbdb-978a-490d-8707-eeb047f01a55",
+          "uri": "../lciamethods/4331bbdb-978a-490d-8707-eeb047f01a55"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.071443807",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.000044188997",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.00029618525",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0000087336574",
+              "module": "C1"
+            },
+            {
+              "value": "0.0000024198562",
+              "module": "C2"
+            },
+            {
+              "value": "0.000040045708",
+              "module": "C3"
+            },
+            {
+              "value": "0.000011557851",
+              "module": "C4"
+            },
+            {
+              "value": "0.00018446909",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg CO2 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "1ebf3012-d0db-4de2-aefd-ef30cedb0be1",
+                "uri": "../unitgroups/1ebf3012-d0db-4de2-aefd-ef30cedb0be1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Global Warming Potential - total (GWP-total)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "6a37f984-a4b3-458a-a20a-64418c145fa2",
+          "uri": "../lciamethods/6a37f984-a4b3-458a-a20a-64418c145fa2"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "-10.547151193",
+              "module": "A1-A3"
+            },
+            {
+              "value": "4.855199",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.24825973",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.022044839",
+              "module": "C1"
+            },
+            {
+              "value": "0.32421993",
+              "module": "C2"
+            },
+            {
+              "value": "42.120931345408",
+              "module": "C3"
+            },
+            {
+              "value": "0.39061325",
+              "module": "C4"
+            },
+            {
+              "value": "1.39884079789",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg CO2 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "1ebf3012-d0db-4de2-aefd-ef30cedb0be1",
+                "uri": "../unitgroups/1ebf3012-d0db-4de2-aefd-ef30cedb0be1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Depletion potential of the stratospheric ozone layer (ODP)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c629d6-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c629d6-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.0000021550416",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.0000010922541",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.000000023972873",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.000000001171931",
+              "module": "C1"
+            },
+            {
+              "value": "0.000000076895486",
+              "module": "C2"
+            },
+            {
+              "value": "0.0000000053888245",
+              "module": "C3"
+            },
+            {
+              "value": "0.000000073211867",
+              "module": "C4"
+            },
+            {
+              "value": "0.00000014837165",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg CFC-11 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "d9e957c9-7309-4474-bf3a-7777df6c4e5b",
+                "uri": "../unitgroups/d9e957c9-7309-4474-bf3a-7777df6c4e5b"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Acidifcation potential, Accumulated Exceedance (AP)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c611c6-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c611c6-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.3766306",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.057286131",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0022730281",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.00006126837",
+              "module": "C1"
+            },
+            {
+              "value": "0.0011376492",
+              "module": "C2"
+            },
+            {
+              "value": "0.00028099549",
+              "module": "C3"
+            },
+            {
+              "value": "0.0011194186",
+              "module": "C4"
+            },
+            {
+              "value": "0.011522",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "mol H+ eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "42e089ac-92bf-4bf2-8ca1-5fc40d18f2ed",
+                "uri": "../unitgroups/42e089ac-92bf-4bf2-8ca1-5fc40d18f2ed"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Europhication potential - freshwater (EP-freshwater)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b53ec18f-7377-4ad3-86eb-cc3f4f276b2b",
+          "uri": "../lciamethods/b53ec18f-7377-4ad3-86eb-cc3f4f276b2b"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.0040291767",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.000002336029",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.00001052152",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0000016675755",
+              "module": "C1"
+            },
+            {
+              "value": "0.00000014788616",
+              "module": "C2"
+            },
+            {
+              "value": "0.0000076307959",
+              "module": "C3"
+            },
+            {
+              "value": "0.00000030908416",
+              "module": "C4"
+            },
+            {
+              "value": "0.000037277932",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg P eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "0429039d-a61d-4590-ba67-aa4a20a810a1",
+                "uri": "../unitgroups/0429039d-a61d-4590-ba67-aa4a20a810a1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Europhication potential - marine (EP-marine)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c619fa-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c619fa-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.14679233",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.026396556",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.00027190826",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0000088308378",
+              "module": "C1"
+            },
+            {
+              "value": "0.0003615939",
+              "module": "C2"
+            },
+            {
+              "value": "0.000040530623",
+              "module": "C3"
+            },
+            {
+              "value": "0.00038137265",
+              "module": "C4"
+            },
+            {
+              "value": "0.0028027555",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg N eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "d05bb823-ecdf-4686-8c40-bf1d9257859f",
+                "uri": "../unitgroups/d05bb823-ecdf-4686-8c40-bf1d9257859f"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Europhication potential - terrestrial (EP-terrestrial)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c614d2-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c614d2-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "1.5812955",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.28998677",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0036128707",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.000099919525",
+              "module": "C1"
+            },
+            {
+              "value": "0.0039789017",
+              "module": "C2"
+            },
+            {
+              "value": "0.00045847492",
+              "module": "C3"
+            },
+            {
+              "value": "0.0039319265",
+              "module": "C4"
+            },
+            {
+              "value": "0.032597682",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "mol N eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "71b4d617-0ec9-4d3f-b65e-e438940c2401",
+                "uri": "../unitgroups/71b4d617-0ec9-4d3f-b65e-e438940c2401"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Photochemical Ozone Creation Potential (POCP)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c610fe-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c610fe-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.37672917",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.06850027",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.00072832534",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.000026595137",
+              "module": "C1"
+            },
+            {
+              "value": "0.00098152588",
+              "module": "C2"
+            },
+            {
+              "value": "0.0001220636",
+              "module": "C3"
+            },
+            {
+              "value": "0.00098927365",
+              "module": "C4"
+            },
+            {
+              "value": "0.0079365944",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg NMVOC eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "d27c25f8-fbc1-44c6-b47b-4adbae4199c6",
+                "uri": "../unitgroups/d27c25f8-fbc1-44c6-b47b-4adbae4199c6"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Abiotic depletion potential - non-fossil resources (ADPE)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b2ad6494-c78d-11e6-9d9d-cec0c932ce01",
+          "uri": "../lciamethods/b2ad6494-c78d-11e6-9d9d-cec0c932ce01"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.000015329829",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.00000020170113",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0000076600701",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.00000000091806341",
+              "module": "C1"
+            },
+            {
+              "value": "0.00000001476777",
+              "module": "C2"
+            },
+            {
+              "value": "0.0000000050346942",
+              "module": "C3"
+            },
+            {
+              "value": "0.000000043155763",
+              "module": "C4"
+            },
+            {
+              "value": "0.0000023008345",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg Sb eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "54ccd2d9-a32a-4fc2-923d-f2c8c93e89d4",
+                "uri": "../unitgroups/54ccd2d9-a32a-4fc2-923d-f2c8c93e89d4"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Abiotic depletion potential - fossil resources (ADPF)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b2ad6110-c78d-11e6-9d9d-cec0c932ce01",
+          "uri": "../lciamethods/b2ad6110-c78d-11e6-9d9d-cec0c932ce01"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "377.26775",
+              "module": "A1-A3"
+            },
+            {
+              "value": "65.224709",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "4.4858437",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.35305174",
+              "module": "C1"
+            },
+            {
+              "value": "4.5911786",
+              "module": "C2"
+            },
+            {
+              "value": "1.6168523",
+              "module": "C3"
+            },
+            {
+              "value": "4.4203805",
+              "module": "C4"
+            },
+            {
+              "value": "22.507303",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "MJ"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "93a60a57-a3c8-11da-a746-0800200c9a66",
+                "uri": "../unitgroups/93a60a57-a3c8-11da-a746-0800200c9a66"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Water (user) deprivation potential (WDP)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b2ad66ce-c78d-11e6-9d9d-cec0c932ce01",
+          "uri": "../lciamethods/b2ad66ce-c78d-11e6-9d9d-cec0c932ce01"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "3.9681326",
+              "module": "A1-A3"
+            },
+            {
+              "value": "-0.014072596",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.19154599",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0035788265",
+              "module": "C1"
+            },
+            {
+              "value": "-0.00022434511",
+              "module": "C2"
+            },
+            {
+              "value": "0.016407198",
+              "module": "C3"
+            },
+            {
+              "value": "0.0088061165",
+              "module": "C4"
+            },
+            {
+              "value": "0.39094168",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "m3 world eq. deprived"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "6ae2df01-888e-46c8-b17d-49fa3869b476",
+                "uri": "../unitgroups/6ae2df01-888e-46c8-b17d-49fa3869b476"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Global Warming Potential (GWP-GHG)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "fb774615-0575-45de-9a89-1ded92f19770",
+          "uri": "../lciamethods/fb774615-0575-45de-9a89-1ded92f19770"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "-5.190951251",
+              "module": "A1-A3"
+            },
+            {
+              "value": "4.821496483928",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.23896935321",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0216509925174",
+              "module": "C1"
+            },
+            {
+              "value": "0.3220474570578",
+              "module": "C2"
+            },
+            {
+              "value": "36.244553608874",
+              "module": "C3"
+            },
+            {
+              "value": "0.376339513269",
+              "module": "C4"
+            },
+            {
+              "value": "1.36676963157",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kg CO2 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "1ebf3012-d0db-4de2-aefd-ef30cedb0be1",
+                "uri": "../unitgroups/1ebf3012-d0db-4de2-aefd-ef30cedb0be1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Particulate Matter emissions (PM)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c602c6-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c602c6-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.000010637811",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.000000055131812",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.000000019485222",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0000000002572703",
+              "module": "C1"
+            },
+            {
+              "value": "0.000000021130809",
+              "module": "C2"
+            },
+            {
+              "value": "0.0000000011863616",
+              "module": "C3"
+            },
+            {
+              "value": "0.000000020831802",
+              "module": "C4"
+            },
+            {
+              "value": "0.00000013162789",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "Disease incidence"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "3883559b-648f-4afc-8ba2-0bd24f3affa3",
+                "uri": "../unitgroups/3883559b-648f-4afc-8ba2-0bd24f3affa3"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Ionizing radiation, human health (IRP)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b5c632be-def3-11e6-bf01-fe55135034f3",
+          "uri": "../lciamethods/b5c632be-def3-11e6-bf01-fe55135034f3"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.52182157",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.2823918",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0067401821",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0027465548",
+              "module": "C1"
+            },
+            {
+              "value": "0.019867043",
+              "module": "C2"
+            },
+            {
+              "value": "0.012578338",
+              "module": "C3"
+            },
+            {
+              "value": "0.019039456",
+              "module": "C4"
+            },
+            {
+              "value": "0.054867",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "kBq U235 eq."
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "456b05bf-1415-44a9-9993-02452f554c09",
+                "uri": "../unitgroups/456b05bf-1415-44a9-9993-02452f554c09"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Eco-toxicity - freshwater (ETP-fw)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "ee1082d1-b0f7-43ca-a1f0-21e2a4a74511",
+          "uri": "../lciamethods/ee1082d1-b0f7-43ca-a1f0-21e2a4a74511"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "390.97633",
+              "module": "A1-A3"
+            },
+            {
+              "value": "22.169828",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "10.50822",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.20843243",
+              "module": "C1"
+            },
+            {
+              "value": "1.877182",
+              "module": "C2"
+            },
+            {
+              "value": "0.95720699",
+              "module": "C3"
+            },
+            {
+              "value": "1.9267547",
+              "module": "C4"
+            },
+            {
+              "value": "34.220946",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "CTUe"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "aa959ded-f1eb-4efb-9c5c-2d60be36b3e6",
+                "uri": "../unitgroups/aa959ded-f1eb-4efb-9c5c-2d60be36b3e6"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Human toxicity, cancer effect (HTP-c)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "2299222a-bbd8-474f-9d4f-4dd1f18aea7c",
+          "uri": "../lciamethods/2299222a-bbd8-474f-9d4f-4dd1f18aea7c"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.00000004310696",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.00000000012176321",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.00000000044426711",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.0000000000035502114",
+              "module": "C1"
+            },
+            {
+              "value": "0.000000000026072507",
+              "module": "C2"
+            },
+            {
+              "value": "0.000000000016923511",
+              "module": "C3"
+            },
+            {
+              "value": "0.000000000030603889",
+              "module": "C4"
+            },
+            {
+              "value": "0.000000015521538",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "CTUh"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "d4c9523e-2d7e-49fd-8469-998f547d3a70",
+                "uri": "../unitgroups/d4c9523e-2d7e-49fd-8469-998f547d3a70"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Human toxicity, non-cancer effects (HTP-nc)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "3af763a5-b7a1-48c9-9cee-1f223481fcef",
+          "uri": "../lciamethods/3af763a5-b7a1-48c9-9cee-1f223481fcef"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "0.0000023813758",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.000000010383941",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "0.0000000096959939",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.00000000010948923",
+              "module": "C1"
+            },
+            {
+              "value": "0.0000000030341042",
+              "module": "C2"
+            },
+            {
+              "value": "0.00000000050411996",
+              "module": "C3"
+            },
+            {
+              "value": "0.0000000029929231",
+              "module": "C4"
+            },
+            {
+              "value": "0.000000023276951",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "CTUh"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "d4c9523e-2d7e-49fd-8469-998f547d3a70",
+                "uri": "../unitgroups/d4c9523e-2d7e-49fd-8469-998f547d3a70"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "referenceToLCIAMethodDataSet": {
+          "shortDescription": [
+            {
+              "value": "Land use related impacts/Soil quality (SQP)",
+              "lang": "en"
+            }
+          ],
+          "type": "LCIA method data set",
+          "refObjectId": "b2ad6890-c78d-11e6-9d9d-cec0c932ce01",
+          "uri": "../lciamethods/b2ad6890-c78d-11e6-9d9d-cec0c932ce01"
+        },
+        "meanAmount": 0.0,
+        "other": {
+          "anies": [
+            {
+              "value": "12233.722",
+              "module": "A1-A3"
+            },
+            {
+              "value": "0.175066",
+              "module": "A4"
+            },
+            {
+              "value": "0",
+              "module": "A5"
+            },
+            {
+              "value": "0",
+              "module": "B1"
+            },
+            {
+              "value": "2.7312629",
+              "module": "B2"
+            },
+            {
+              "value": "0",
+              "module": "B3"
+            },
+            {
+              "value": "0",
+              "module": "B4"
+            },
+            {
+              "value": "0",
+              "module": "B5"
+            },
+            {
+              "value": "0",
+              "module": "B6"
+            },
+            {
+              "value": "0",
+              "module": "B7"
+            },
+            {
+              "value": "0.043392202",
+              "module": "C1"
+            },
+            {
+              "value": "0.011970576",
+              "module": "C2"
+            },
+            {
+              "value": "0.19883487",
+              "module": "C3"
+            },
+            {
+              "value": "0.50709108",
+              "module": "C4"
+            },
+            {
+              "value": "-113.59125",
+              "module": "D"
+            },
+            {
+              "name": "referenceToUnitGroupDataSet",
+              "value": {
+                "shortDescription": [
+                  {
+                    "value": "dimensionless"
+                  }
+                ],
+                "type": "unit group data set",
+                "refObjectId": "f130951c-e67f-4f7f-8dd4-665de3974e18",
+                "uri": "../unitgroups/f130951c-e67f-4f7f-8dd4-665de3974e18"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "otherAttributes": {
+    "{http://www.indata.network/EPD/2019}epd-version": "1,2"
+  },
+  "version": "1.1",
+  "source": "https://data.environdec.com/resource/datastocks/a6c533b3-502e-47b9-885d-31304bf15c64/processes/b56530ee-77bf-49bd-7997-08d972c43176?version=07.01.002"
+}

--- a/modules/convert/tests/ilcd/test_parse_ilcd.rs
+++ b/modules/convert/tests/ilcd/test_parse_ilcd.rs
@@ -75,6 +75,7 @@ parse_ilcd_a1_tests! {
     ilcd_0aa8b645: ("0aa8b645-02d9-41b4-8aa3-70335af2a9e7.json", "a2")
     ilcd_335241f9: ("335241f9-db84-486c-9a19-cd5ebb791903.json", "a2")
     ilcd_503dfca1: ("503dfca1-7c65-4179-9ffa-ebc6d8b48b7d.json", "a2")
+    ilcd_b56530ee: ("b56530ee-77bf-49bd-7997-08d972c43176.json", "a2")
 }
 
 #[test]


### PR DESCRIPTION
Fixes problems with no "other" field in LCIMethodAndAllocation and thereby subtype in ILCD data.

Resolves #85